### PR TITLE
IFF Acquisition and processing with Shuffling and Multiple repetitions options

### DIFF
--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -44,6 +44,19 @@ applyTo: '**/*.py'
 - Always prioritize code performance (speed)
 - Never change the core functionality of the code when optimizing for performance, unless explicitly asked to do so.
 
+## Commit message generation
+- When generating commit messages, ensure they are well explicative and follow the format: `<mod> <type>: <subject>`, where:
+    - `<mod>` is the name of the module, file or Class being changed, without the path or extension.
+    - `<type>` is one of the following: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`.
+    - `<subject>` is a description of the change, concise but informative enough to understand the change without looking at the code.
+- When a new function is added, the commit message should include the name of the function and a brief description of its purpose.
+- If `__version__` is updated, the commit message should include the new version number and a summary of the changes included in that version.
+
+### Example of commit messages
+- `iff_processing refactor: optimized mode matrix processing for generalized use cases and better performance`
+- `ComputeReconstructor perf: improved performance of reconstructor computation by optimizing matrix operations and reducing redundant calculations`
+- `iff_processing feat: added ``_squash_mode_matrix`` function to handle cases with shuffle disabled`
+
 ## Example of Proper Documentation
 
 ```python

--- a/opticalib/__init__.py
+++ b/opticalib/__init__.py
@@ -44,7 +44,9 @@ from . import (
     ground,
     dmutils,
     simulator,
+    visualization,
 )
+vis = visualization
 
 __all__ = [
     "analyzer",
@@ -52,6 +54,7 @@ __all__ = [
     "ground",
     "dmutils",
     "simulator",
+    "visualization",
     "load_fits",
     "save_fits",
     "read_phasemap",

--- a/opticalib/__init_script__/initCalpy.py
+++ b/opticalib/__init_script__/initCalpy.py
@@ -12,6 +12,7 @@ modal_decomposer = zern = opticalib.ground.modal_decomposer
 osutils = osu = opticalib.ground.osutils
 analyzer = az = opticalib.analyzer
 simulator = sim = opticalib.simulator
+oplt = opticalib.visualization
 
 ifp = dmutils.iff_processing
 ifm = dmutils.iff_module

--- a/opticalib/analyzer/images_processing.py
+++ b/opticalib/analyzer/images_processing.py
@@ -110,9 +110,8 @@ def piston_unwrap(
 def pushPullReductionAlgorithm(
     imagelist: list[_ot.ImageData] | _ot.CubeData,
     template: _ot.ArrayLike,
-    normalization: _ot.Optional[float | int] = None,
-    shuffle: int = 0,
-):
+    normalization: _ot.Optional[float | int] = None
+) -> _ot.ImageData:
     """
     Performs the basic operation of processing PushPull data.
 
@@ -133,43 +132,29 @@ def pushPullReductionAlgorithm(
     """
     template = _np.asarray(template)
     n_images = len(imagelist)
-    if shuffle == 0:
-        # Template weights computation
-        w = _xp.asarray(
-            template.astype(_np.result_type(template, imagelist[0].data), copy=True),
-            dtype=_xp.float,
-        )
-        if n_images > 2:
-            w[1:-1] *= 2.0
-        # OR-reduce all masks once
-        master_mask = _np.logical_or.reduce([ima.mask for ima in imagelist])
-        # Compute weighted sum over realizations on raw data
-        stack = _xp.stack(
-            [_xp.asarray(ima.data, dtype=_xp.float) for ima in imagelist],
-            axis=0,
-            dtype=_xp.float,
-        )  # (n, H, W)
-        image = _xp.asnumpy(_xp.tensordot(w, stack, axes=(0, 0)))  # (H, W)
-    else:
-        print("Shuffle option")
-        for i in range(0, shuffle - 1):
-            for x in range(1, 2):
-                opd2add = (
-                    imagelist[i * 3 + x] * template[x]
-                    + imagelist[i * 3 + x - 1] * template[x - 1]
-                )
-                master_mask2add = _np.ma.mask_or(
-                    imagelist[i * 3 + x].mask, imagelist[i * 3 + x - 1].mask
-                )
-                if i == 0 and x == 1:
-                    master_mask = master_mask2add
-                else:
-                    master_mask = _np.ma.mask_or(master_mask, master_mask2add)
-                image += opd2add
+
+    # Template weights computation
+    w = _xp.asarray(
+        template.astype(_np.result_type(template, imagelist[0].data), copy=True),
+        dtype=_xp.float,
+    )
+    if n_images > 2:
+        w[1:-1] *= 2.0
+    # OR-reduce all masks once
+    master_mask = _np.logical_or.reduce([ima.mask for ima in imagelist])
+    # Compute weighted sum over realizations on raw data
+    stack = _xp.stack(
+        [_xp.asarray(ima.data, dtype=_xp.float) for ima in imagelist],
+        axis=0,
+        dtype=_xp.float,
+    )  # (n, H, W)
+    image = _xp.asnumpy(_xp.tensordot(w, stack, axes=(0, 0)))  # (H, W)
+
     if normalization is None:
         norm_factor = _np.max(((template.shape[0] - 1), 1))
     else:
         norm_factor = normalization
+
     image = _np.ma.masked_array(image, mask=master_mask) / norm_factor
     return image
 

--- a/opticalib/core/read_config.py
+++ b/opticalib/core/read_config.py
@@ -182,12 +182,16 @@ def getIffConfig(key: str, bpath: str = _cfold):
         cc = config["INFLUENCE.FUNCTIONS"][key]
     except KeyError:
         cc = config[key]
+    
+    if key == 'DM':
+        return cc
+
     nzeros = int(cc[_nzeroName])
     modeId = _parse_val(cc[_modeIdName])
     modeAmp = _parse_val(cc[_modeAmpName])
     modalBase = cc[_modalBaseName]
     template = _parse_val(cc[_templateName])
-    info = {
+    return {
         "zeros": nzeros,
         "modes": modeId,
         "amplitude": modeAmp,
@@ -195,8 +199,6 @@ def getIffConfig(key: str, bpath: str = _cfold):
         "modalBase": modalBase,
         "paddingZeros": cc.get("paddingZeros", 0),
     }
-    return info
-
 
 def copyIffConfigFile(tn: str, old_path: str = _cfold):
     """
@@ -301,27 +303,6 @@ def updateConfigFile(key: str, item: str, value: _Any, bpath: str = _cfold):
     else:
         config["INFLUENCE.FUNCTIONS"][key][item] = str(value)
     dump_yaml_config(config, bpath)
-
-
-def getDmIffConfig(bpath: str = _cfold):
-    """
-    Retrieves the DM configuration from the YAML file.
-
-    Parameters
-    ----------
-    bpath : str, optional
-        Base path of the configuration file.
-
-    Returns
-    -------
-    config : dict
-        The DM configuration dictionary.
-    """
-    config = load_yaml_config(bpath)
-    try:
-        return config["INFLUENCE.FUNCTIONS"]["DM"]
-    except KeyError:
-        return config["DM"]
 
 
 def getNActs(bpath: str = _cfold):

--- a/opticalib/devices/_API/piAPI.py
+++ b/opticalib/devices/_API/piAPI.py
@@ -2,7 +2,7 @@ import numpy as np
 from opticalib import typings as _ot
 from pipython import GCSDevice, GCSError
 from pipython.pidevice.interfaces.pisocket import PISocket
-from opticalib.core.read_config import getDmConfig, getDmIffConfig as _dmc
+from opticalib.core.read_config import getDmConfig, getIffConfig as _dmc
 
 
 class BasePetalMirror:
@@ -46,8 +46,8 @@ class BasePetalMirror:
         self.nSegments = len(self._devices)
         self.nActsPerSegment = 3
         self.nActs = self.nSegments * self.nActsPerSegment
-        self._slaveIds = _dmc().get("slaveIds", [])
-        self._borderIds = _dmc().get("borderIds", [])
+        self._slaveIds = _dmc('DM').get("slaveIds", [])
+        self._borderIds = _dmc('DM').get("borderIds", [])
 
     @property
     def slaveIds(self):
@@ -248,11 +248,11 @@ class BasePetalMirror:
                 print(f"Reinitialization attempt {i+1}/10...", end="\r", flush=True)
                 try:
                     self = self.__init__()
+                    break
                 except ConnectionRefusedError as err:
                     self._logger.error(f"Error reinitializing: {err}")
-                finally:
-                    continue
-            self = self.__init__()
+            else:
+                self = self.__init__()
 
     def _enable_axes(self) -> None:
         """

--- a/opticalib/devices/deformable_mirrors.py
+++ b/opticalib/devices/deformable_mirrors.py
@@ -9,6 +9,8 @@ Description
 -----------
 
 """
+# FIXME - Change the reading path of _dmc -> slave ids should not be read from the dm
+#           configuration of IFF section
 
 import os as _os
 import numpy as _np
@@ -17,7 +19,7 @@ from . import _API as _api
 from opticalib import typings as _ot
 from opticalib.core import exceptions as _oe
 from contextlib import contextmanager as _contextmanager
-from opticalib.core.read_config import getDmIffConfig as _dmc
+from opticalib.core.read_config import getIffConfig as _dmc
 from opticalib.core.root import OPD_IMAGES_ROOT_FOLDER as _opdi
 from opticalib.ground.osutils import (
     newtn as _ts, save_fits as _sf, create_data_folder as _cdf
@@ -101,7 +103,7 @@ class PetalMirror(_api.BasePetalMirror, _api.base_devices.BaseDeformableMirror):
         """
         self._logger.info("Starting to run the command history")
 
-        iff_config = _dmc()
+        iff_config = _dmc('DM')
 
         if self.cmdHistory is None:
             self._logger.error("MatrixError: No Command History to run!")
@@ -151,8 +153,8 @@ class AdOpticaDm(_api.BaseAdOpticaDm, _api.base_devices.BaseDeformableMirror):
         self._name = "AdOpticaDM"
         super().__init__(tn)
         self._last_cmd = _np.zeros(self.nActs)
-        self._slaveIds = _dmc().get("slaveIds", [])
-        self._borderIds = _dmc().get("borderIds", [])
+        self._slaveIds = _dmc('DM').get("slaveIds", [])
+        self._borderIds = _dmc('DM').get("borderIds", [])
 
     @property
     def slaveIds(self):
@@ -301,7 +303,7 @@ class AdOpticaDm(_api.BaseAdOpticaDm, _api.base_devices.BaseDeformableMirror):
                 f"Expecting a 2D Matrix of shape (used_acts, nmodes), got instead: {tcmdhist.shape}"
             )
         tcmdhist += self._last_cmd[:, None]
-        trig = _dmc()["triggerMode"]
+        trig = _dmc('DM')["triggerMode"]
         self.cmdHistory = tcmdhist.copy()
         if trig is not False:
             self._aoClient.timeHistoryUpload(tcmdhist)
@@ -334,7 +336,7 @@ class AdOpticaDm(_api.BaseAdOpticaDm, _api.base_devices.BaseDeformableMirror):
         save : str, optional
             If provided, the command history will be saved with this name as a timestamp.
         """
-        dmifconf = _dmc()
+        dmifconf = _dmc('DM')
         triggered = dmifconf["triggerMode"]
         sequential_delay = dmifconf["sequentialDelay"]
         if triggered is not False:
@@ -466,7 +468,7 @@ class DP(AdOpticaDm):
             raise _oe.BufferError(
                 "Missing `total_frames` value: either load a command history or provide the variable's value"
             )
-        triggered = _dmc()["triggerMode"]
+        triggered = _dmc('DM')["triggerMode"]
         if triggered is not False:
             thistfreq = triggered.get("frequency", 1.0)
         if segment == 0:
@@ -592,8 +594,8 @@ class AlpaoDm(_api.BaseAlpaoMirror, _api.base_devices.BaseDeformableMirror):
         super().__init__(serial_number, nacts)
         self.set_zeros_to_acts()
         self.is_segmented = False
-        self._slaveIds = _dmc().get("slaveIds", [])
-        self._borderIds = _dmc().get("borderIds", [])
+        self._slaveIds = _dmc('DM').get("slaveIds", [])
+        self._borderIds = _dmc('DM').get("borderIds", [])
         self.has_slaved_acts = False if len(self._slaveIds) == 0 else True
 
     @property
@@ -674,7 +676,7 @@ class AlpaoDm(_api.BaseAlpaoMirror, _api.base_devices.BaseDeformableMirror):
             Tracking number of the directory where the images are saved.
 
         """
-        iff_config = _dmc()
+        iff_config = _dmc('DM')
         delay: float = iff_config.get("delay", 0.0)
 
         if self.cmdHistory is None:
@@ -786,8 +788,8 @@ class SplattDm(_api.base_devices.BaseDeformableMirror):
         self.baseDataPath = _opdi
         self.refAct = 16
         self.is_segmented = False
-        self._slaveIds = _dmc().get("slaveIds", [])
-        self._borderIds = _dmc().get("borderIds", [])
+        self._slaveIds = _dmc('DM').get("slaveIds", [])
+        self._borderIds = _dmc('DM').get("borderIds", [])
         self._logger = _SL(the_class=__class__)
 
     @property

--- a/opticalib/dmutils/iff_acquisition_preparation.py
+++ b/opticalib/dmutils/iff_acquisition_preparation.py
@@ -13,6 +13,7 @@ import os as _os
 import numpy as _np
 from opticalib.ground import osutils as _osu
 from opticalib.core import read_config as _rif
+from opticalib.core.fitsarray import fits_array as _fa
 from opticalib import typings as _ot
 from .iff_processing import _getAcqInfo
 
@@ -71,8 +72,11 @@ class IFFCapturePreparation:
             from opticalib.core.exceptions import DeviceError
 
             raise DeviceError(dm, "DeformableMirrorDevice")
+
+        self._dm = dm
         self.mirrorModes = dm.mirrorModes
         self._NActs = dm.nActs
+
         # IFF info
         self.modalBaseId = None
         self._modesList = None
@@ -82,7 +86,8 @@ class IFFCapturePreparation:
         self._indexingList = None
         self._modesAmp = None
         self._template = None
-        self._shuffle = 0
+        self._shuffle = False
+
         # Matrices
         self.timedCmdHistory = None
         self.cmdMatHistory = None
@@ -93,11 +98,14 @@ class IFFCapturePreparation:
     def createTimedCmdHistory(
         self,
         cmdMat: _ot.Optional[_ot.MatrixLike] = None,
+        triggerMat: _ot.Optional[_ot.MatrixLike] = None,
+        registrationMat: _ot.Optional[_ot.MatrixLike] = None,
         modesList: _ot.Optional[_ot.ArrayLike] = None,
         modesAmp: _ot.Optional[float | _ot.ArrayLike] = None,
         template: _ot.Optional[_ot.ArrayLike] = None,
         modalBase: str = None,
         shuffle: bool = False,
+        n_repetitions: int = 1,
     ) -> _ot.MatrixLike:
         """
         Function that creates the final timed command history to be applied
@@ -108,6 +116,12 @@ class IFFCapturePreparation:
             Command matrix to be used. Default is None, that means the command
             matrix is created using the 'modesList' argument or the configuration
             file.
+        triggerMat : MatrixLike
+            Trigger matrix to be used. Default is None, that means the trigger
+            matrix is created using the configuration file.
+        registrationMat : MatrixLike
+            Registration matrix to be used. Default is None, that means the
+            registration matrix is created using the configuration file.
         modesList : int | ArrayLike
             List of selected modes to use. Default is None, that means all modes
             of the base command matrix are used.
@@ -122,6 +136,8 @@ class IFFCapturePreparation:
         modalBase : str, optional
             Modal base to use. Default is None, which means the modal base is
             loaded from the 'iffconfig.ini' file.
+        n_repetitions : int
+            Number of times the command matrix is repeated. Default is 1.
 
         Returns
         -------
@@ -129,13 +145,8 @@ class IFFCapturePreparation:
             Final timed command history, including the trigger padding, the
             registration pattern and the command matrix history.
         """
-        if self.cmdMatHistory is None:
-            self.createCmdMatrixHistory(
-                modesList, modesAmp, template, modalBase, shuffle
-            )
-
         # Provide manually the cmdMatrixHistory
-        elif cmdMat is not None:
+        if cmdMat is not None:
             _, _, infoIF = _getAcqInfo()
             trailing_zeros = _np.zeros((cmdMat.shape[0], infoIF["paddingZeros"]))
             self._cmdMatrix = cmdMat
@@ -146,11 +157,21 @@ class IFFCapturePreparation:
             self._template = template
             self._shuffle = shuffle
             self._indexingList = _np.arange(0, len(modesList), 1)
+            self._n_repetitions = n_repetitions
+
+        elif self.cmdMatHistory is None:
+            self.createCmdMatrixHistory(
+                modesList, modesAmp, template, modalBase, shuffle, n_repetitions
+            )
+
+        self.triggPadCmdHist = triggerMat.copy() if triggerMat is not None else None
+        self.regPadCmdHist = registrationMat.copy() if registrationMat is not None else None
 
         # Create the auxiliary command history if needed
         if self.auxCmdHistory is None:
             self.createAuxCmdHistory()
-        if not self.auxCmdHistory is None:
+
+        if self.auxCmdHistory is not None:
             cmdHistory = _np.hstack((self.auxCmdHistory, self.cmdMatHistory))
         else:
             cmdHistory = self.cmdMatHistory
@@ -184,19 +205,21 @@ class IFFCapturePreparation:
 
     def createCmdMatrixHistory(
         self,
-        mlist: _ot.Optional[_ot.ArrayLike] = None,
+        modesList: _ot.Optional[_ot.ArrayLike] = None,
         modesAmp: _ot.Optional[float | _ot.ArrayLike] = None,
         template: _ot.Optional[_ot.ArrayLike] = None,
         modalBase: _ot.Optional[str] = None,
         shuffle: bool = False,
+        n_repetitions: int = 1,
     ) -> _ot.MatrixLike:
         """
         Creates the command matrix history for the IFF acquisition.
 
         Parameters
         ----------
-        mlist : ArrayLike
+        modesList : ArrayLike
             List of selected modes to use. If no argument is passed, it will
+            be loaded from the configuration file iffConfig.ini
         modesAmp : float | ArrayLike
             Amplitude of the modes to be commanded. If no argument is passed,
             it will be loaded from the configuration file iffConfig.ini
@@ -209,6 +232,9 @@ class IFFCapturePreparation:
         shuffle : bool
             Decides to wether shuffle or not the order in which the modes are
             applied. Default is False
+        n_repetitions : int
+            Number of times the command matrix is repeated. 
+            Default is 1.
 
         Returns
         -------
@@ -217,50 +243,88 @@ class IFFCapturePreparation:
             application, following the desired template.
         """
         _, _, infoIF, _ = _getAcqInfo()
-        if mlist is None:
-            mlist = infoIF.get("modes")
-        else:
-            mlist = mlist
-            infoIF["modes"] = mlist
+        modesList = _np.asarray(
+            modesList if modesList is not None else infoIF.get("modes"),
+            dtype=int
+        )
+        template = _np.asarray(
+            template if template is not None else infoIF.get("template"),
+            dtype=int
+        )
         modesAmp = modesAmp if modesAmp is not None else infoIF.get("amplitude")
-        template = template if template is not None else infoIF.get("template")
         zeroScheme = infoIF["zeros"]
-        self._template = template
-        self._modesList = mlist
-        self._createCmdMatrix(mlist, modalBase)
-        nModes = self._cmdMatrix.shape[1]
+
+        self._createCmdMatrix(modesList, modalBase)
+        A, M = self._cmdMatrix.shape
         n_push_pull = len(template)
+
         if _np.size(modesAmp) == 1:
-            modesAmp = _np.full(nModes, modesAmp)
-        self._modesAmp = modesAmp
-        if shuffle is not False:
-            self._shuffle = shuffle
-            cmd_matrix = _np.zeros((self._cmdMatrix.shape[0], self._cmdMatrix.shape[1]))
-            modesList = _np.copy(self._modesList)
-            _np.random.shuffle(modesList)
-            k = 0
-            for i in modesList:
-                cmd_matrix.T[k] = self._cmdMatrix[i]
-                k += 1
-            self._indexingList = _np.arange(0, len(modesList), 1)
+            modesAmp = _np.full(M, modesAmp)
+        elif _np.size(modesAmp) != M:
+            raise ValueError(
+                f"Length of modesAmp ({_np.size(modesAmp)}) must be either 1 or"
+                f" equal to the number of modes ({M})"
+            )
+
+        if shuffle is not False:            
+            final_cmd_mat = _np.zeros(
+                (A, M * n_repetitions)
+            )
+            final_mlist = _np.zeros(M * n_repetitions, dtype=int)
+            final_ilist = _np.zeros(M * n_repetitions, dtype=int)
+            final_amps  = _np.zeros(len(modesAmp) * n_repetitions)
+            
+            for R in range(n_repetitions):
+                indexList = _np.arange(M)
+                _np.random.shuffle(indexList)
+                
+                cmd_matrix = self._cmdMatrix[:, indexList]
+                final_cmd_mat[:, R*M:(R+1)*M] = cmd_matrix
+                final_ilist[R*M:(R+1)*M] = indexList
+                final_mlist[R*M:(R+1)*M] = modesList[indexList]
+                final_amps[R*M:(R+1)*M] = modesAmp[indexList]
+
         else:
-            cmd_matrix = self._cmdMatrix
-            modesList = self._modesList
-            self._indexingList = _np.arange(0, len(modesList), 1)
-        n_frame = len(self._modesList) * n_push_pull
+            final_cmd_mat = _np.tile(self._cmdMatrix, (1, n_repetitions))
+            final_mlist = _np.tile(modesList, n_repetitions)
+            final_ilist = _np.tile(_np.arange(len(modesList)), n_repetitions)
+            final_amps = _np.tile(modesAmp, n_repetitions)
+
+        n_frame = len(final_mlist) * n_push_pull
         cmd_matrixHistory = _np.zeros(
             (self._NActs, n_frame + zeroScheme + infoIF["paddingZeros"])
-        )  # TODO -> fix it by reading a new configuration entry, like 'paddingZeros'
-        k = zeroScheme
-        for i in range(nModes):
-            for j in range(n_push_pull):
-                # k = zeroScheme + cmd_matrix.shape[1]*j + i
-                cmd_matrixHistory.T[k] = cmd_matrix[:, i] * template[j] * modesAmp[i]
-                k += 1
-        self.cmdMatHistory = cmd_matrixHistory
-        return cmd_matrixHistory
+        )
+        n_modes = final_cmd_mat.shape[1]
 
-    def createAuxCmdHistory(self) -> _ot.MatrixLike:
+        k = zeroScheme
+        for i in range(n_modes):
+            # for j in range(n_push_pull):
+            #     cmd_matrixHistory.T[k] = final_cmd_mat[:, i] * template[j] * modesAmp[i]
+            #     k += 1
+            scaled_cmd = final_cmd_mat[:, i:i+1] * template[_np.newaxis, :] * final_amps[i]
+            cmd_matrixHistory[:, k:k+n_push_pull] = scaled_cmd
+            k += n_push_pull
+        
+        header = {
+            'SHUFFLE': shuffle,
+            'N_REP': n_repetitions,
+        }
+
+        cmdMatHist = _fa(
+            cmd_matrixHistory,
+            header=header
+        )
+        
+        self._modesList = _fa(final_mlist, header=header)
+        self._indexingList = _fa(final_ilist, header=header)
+        self._modesAmp = _fa(final_amps, header=header)
+        self._template = _fa(template)
+        self._shuffle = shuffle
+        self._n_repetitions = n_repetitions
+        self.cmdMatHistory = cmdMatHist.copy()
+        return cmdMatHist
+
+    def createAuxCmdHistory(self) -> _ot.Optional[_ot.MatrixLike]:
         """
         Creates the initial part of the final command history matrix that will
         be passed to M4. This includes the Trigger Frame, the first frame to
@@ -269,35 +333,30 @@ class IFFCapturePreparation:
 
         Result
         ------
-        aus_cmdHistory : MatrixLike
+        aus_cmdHistory : MatrixLike or None
             The auxiliary command history, which includes the trigger padding
             and the registration pattern. This matrix is used to create the
             final command history to be passed to the DM.
         """
-        self._createTriggerPadding()
-        self._createRegistrationPattern()
-        if self.triggPadCmdHist is not None and self.regPadCmdHist is not None:
-            aux_cmdHistory = _np.hstack((self.triggPadCmdHist, self.regPadCmdHist))
-        elif self.triggPadCmdHist is not None:
-            aux_cmdHistory = self.triggPadCmdHist
-        elif self.regPadCmdHist is not None:
-            aux_cmdHistory = self.regPadCmdHist
-        else:
-            aux_cmdHistory = None
+        self._createTriggerPadding() if self.triggPadCmdHist is None else None
+        self._createRegistrationPattern() if self.regPadCmdHist is None else None
+        # if self.triggPadCmdHist is not None and self.regPadCmdHist is not None:
+        #     aux_cmdHistory = _np.hstack((self.triggPadCmdHist, self.regPadCmdHist))
+        # elif self.triggPadCmdHist is not None:
+        #     aux_cmdHistory = self.triggPadCmdHist
+        # elif self.regPadCmdHist is not None:
+        #     aux_cmdHistory = self.regPadCmdHist
+        # else:
+        #     aux_cmdHistory = None
+        matrices = [m for m in [self.triggPadCmdHist, self.regPadCmdHist] if m is not None]
+        aux_cmdHistory = _np.hstack(matrices) if matrices else None
         self.auxCmdHistory = aux_cmdHistory
-        return aux_cmdHistory
 
-    def _createRegistrationPattern(self) -> _ot.MatrixLike:
+    def _createRegistrationPattern(self) -> None:
         """
         Creates the registration pattern to apply after the triggering and before
         the commands to apply for the IFF acquisition. The information about number
         of zeros, mode(s) and amplitude are read from the 'iffconfig.ini' file.
-
-        Returns
-        -------
-        regHist : MatrixLike
-            Registration pattern command history
-
         """
         infoR = _rif.getIffConfig("REGISTRATION")
         if len(infoR["modes"]) == 0:
@@ -317,19 +376,13 @@ class IFFCapturePreparation:
                 )
                 k += 1
         regHist = _np.hstack((zeroScheme, regScheme))
-        self.regPadCmdHist = regHist
-        return regHist
+        self.regPadCmdHist = regHist.copy()
 
-    def _createTriggerPadding(self) -> _ot.MatrixLike:
+    def _createTriggerPadding(self) -> None:
         """
         Function that creates the trigger padding scheme to apply before the
         registration padding scheme. The information about number of zeros,
         mode(s) and amplitude are read from the 'iffconfig.ini' file.
-
-        Returns
-        -------
-        triggHist : MatrixLike
-            Trigger padding command history
         """
         infoT = _rif.getIffConfig("TRIGGER")
         if len(infoT["modes"]) == 0:
@@ -338,12 +391,11 @@ class IFFCapturePreparation:
         zeroScheme = _np.zeros((self._NActs, infoT["zeros"]))
         trigMode = self._modalBase[:, infoT["modes"]] * infoT["amplitude"]
         triggHist = _np.hstack((zeroScheme, trigMode))
-        self.triggPadCmdHist = triggHist
-        return triggHist
+        self.triggPadCmdHist = triggHist.copy()
 
     def _createCmdMatrix(
         self, mlist: int | _ot.ArrayLike, mbase: str = None
-    ) -> _ot.MatrixLike:
+    ) -> None:
         """
         Cuts the modal base according the given modes list
         """
@@ -351,7 +403,6 @@ class IFFCapturePreparation:
         modalbase = mbase or infoIF["modalBase"]
         self._updateModalBase(modalbase)
         self._cmdMatrix = self._modalBase[:, mlist]
-        return self._cmdMatrix
 
     def _updateModalBase(self, mbasename: _ot.Optional[str] = None) -> None:
         """

--- a/opticalib/dmutils/iff_acquisition_preparation.py
+++ b/opticalib/dmutils/iff_acquisition_preparation.py
@@ -95,6 +95,27 @@ class IFFCapturePreparation:
         self.triggPadCmdHist = None
         self.regPadCmdHist = None
 
+    def getInfoToSave(self) -> dict[str, _ot.Any]:
+        """
+        Return the data to save as fits files, arranged in a dictionary
+
+        Returns
+        -------
+        info : dict
+            Dictionary containing all the vectors and matrices needed
+        """
+        info = {
+            "timedCmdHistory": self.timedCmdHistory,
+            "cmdMatrix": self._cmdMatrix,
+            "modesVector": self._modesList,
+            "regActs": self._regActs,
+            "ampVector": self._modesAmp,
+            "indexList": self._indexingList,
+            "template": self._template,
+            "shuffle": self._shuffle,
+        }
+        return info
+
     def createTimedCmdHistory(
         self,
         cmdMat: _ot.Optional[_ot.MatrixLike] = None,
@@ -159,10 +180,9 @@ class IFFCapturePreparation:
             self._indexingList = _np.arange(0, len(modesList), 1)
             self._n_repetitions = n_repetitions
 
-        elif self.cmdMatHistory is None:
-            self.createCmdMatrixHistory(
-                modesList, modesAmp, template, modalBase, shuffle, n_repetitions
-            )
+        self.createCmdMatrixHistory(
+            modesList, modesAmp, template, modalBase, shuffle, n_repetitions
+        )
 
         self.triggPadCmdHist = triggerMat.copy() if triggerMat is not None else None
         self.regPadCmdHist = registrationMat.copy() if registrationMat is not None else None
@@ -181,27 +201,6 @@ class IFFCapturePreparation:
         timedCmdHist = _np.repeat(cmdHistory, timing, axis=1)
         self.timedCmdHistory = timedCmdHist
         return timedCmdHist
-
-    def getInfoToSave(self) -> dict[str, _ot.Any]:
-        """
-        Return the data to save as fits files, arranged in a dictionary
-
-        Returns
-        -------
-        info : dict
-            Dictionary containing all the vectors and matrices needed
-        """
-        info = {
-            "timedCmdHistory": self.timedCmdHistory,
-            "cmdMatrix": self._cmdMatrix,
-            "modesVector": self._modesList,
-            "regActs": self._regActs,
-            "ampVector": self._modesAmp,
-            "indexList": self._indexingList,
-            "template": self._template,
-            "shuffle": self._shuffle,
-        }
-        return info
 
     def createCmdMatrixHistory(
         self,
@@ -310,10 +309,7 @@ class IFFCapturePreparation:
             'N_REP': n_repetitions,
         }
 
-        cmdMatHist = _fa(
-            cmd_matrixHistory,
-            header=header
-        )
+        cmdMatHist = _fa(cmd_matrixHistory,header=header)
         
         self._modesList = _fa(final_mlist, header=header)
         self._indexingList = _fa(final_ilist, header=header)
@@ -351,6 +347,7 @@ class IFFCapturePreparation:
         matrices = [m for m in [self.triggPadCmdHist, self.regPadCmdHist] if m is not None]
         aux_cmdHistory = _np.hstack(matrices) if matrices else None
         self.auxCmdHistory = aux_cmdHistory
+        return aux_cmdHistory
 
     def _createRegistrationPattern(self) -> None:
         """

--- a/opticalib/dmutils/iff_acquisition_preparation.py
+++ b/opticalib/dmutils/iff_acquisition_preparation.py
@@ -253,6 +253,11 @@ class IFFCapturePreparation:
         modesAmp = modesAmp if modesAmp is not None else infoIF.get("amplitude")
         zeroScheme = infoIF["zeros"]
 
+        if n_repetitions < 1:
+            raise ValueError(
+                f"n_repetitions must be >= 1, got {n_repetitions}"
+            )
+
         self._createCmdMatrix(modesList, modalBase)
         A, M = self._cmdMatrix.shape
         n_push_pull = len(template)

--- a/opticalib/dmutils/iff_acquisition_preparation.py
+++ b/opticalib/dmutils/iff_acquisition_preparation.py
@@ -179,10 +179,10 @@ class IFFCapturePreparation:
             self._shuffle = shuffle
             self._indexingList = _np.arange(0, len(modesList), 1)
             self._n_repetitions = n_repetitions
-
-        self.createCmdMatrixHistory(
-            modesList, modesAmp, template, modalBase, shuffle, n_repetitions
-        )
+        else:
+            self.createCmdMatrixHistory(
+                modesList, modesAmp, template, modalBase, shuffle, n_repetitions
+            )
 
         self.triggPadCmdHist = triggerMat.copy() if triggerMat is not None else None
         self.regPadCmdHist = registrationMat.copy() if registrationMat is not None else None

--- a/opticalib/dmutils/iff_module.py
+++ b/opticalib/dmutils/iff_module.py
@@ -26,6 +26,7 @@ def iffDataAcquisition(
     template: _ot.Optional[_ot.ArrayLike] = None,
     modalbase: _ot.Optional[str] = None,
     shuffle: bool = False,
+    n_repetitions: int = 1,
     read_buffer: bool | dict[str, _ot.Any] = False,
 ) -> str:
     """
@@ -70,6 +71,7 @@ def iffDataAcquisition(
         template=template,
         shuffle=shuffle,
         modalBase=modalbase,
+        n_repetitions=n_repetitions,
     )
     info = ifc.getInfoToSave()
     tn, _ = _prepareData2Save(info)

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -64,7 +64,6 @@ _AMP_FILE = "ampVector.fits"
 _TEMPLATE_FILE = "template.fits"
 _REGACTS_FILE = "regActs.fits"
 _INDEXLIST_FILE = "indexList.fits"
-_SHUFFLE_FILE = "shuffle.dat"
 _CUBE_FILE = "IMCube.fits"
 _COORD_FILE = ""  # TODO
 
@@ -119,28 +118,42 @@ def process(
         ntn = stackCubes(tn)
         return ntn
 
-    ampVector, modesVector, template, _, registrationActs, shuffle = _getAcqPar(tn)
-    if not modesVector.dtype.type is _np.int_:
-        modesVector = modesVector.astype(int)
+    info = _getAcqPar(tn)
+    if not info["modesVector"].dtype.type is _np.int_:
+        info["modesVector"] = info["modesVector"].astype(int)
+    
+    for k, dic in zip(
+        ['TRIGGER','REGISTRATION','IFFUNC','DM'], _getAcqInfo(tn)
+    ):
+        info.update({k: dic})
+
     new_fold = _os.path.join(_intMatFold, tn)
     if not _os.path.exists(new_fold):
         _os.mkdir(new_fold)
+
     trigFrame = getTriggerFrame(tn, roi=trigger_roi)
-    regMat = getRegFileMatrix(tn, trigFrame)
-    modesMat = getIffFileMatrix(tn, trigFrame)
+    info["trigFrame"] = trigFrame
+
+    _check_information_consistency(info)
+    
+    regMat = getRegFileMatrix(tn, info)
+    modesMat = getIffFileMatrix(tn, info)
+    
+    modesMat = _modes_matrix_reorganization(modesMat, info)
+
     iffRedux(
         tn=tn,
         fileMat=modesMat,
-        ampVect=ampVector,
-        modeList=modesVector,
-        template=template,
-        shuffle=shuffle,
+        ampVect=info["ampVector"],
+        modeList=info["modesVector"],
+        template=info["template"],
+        shuffle=info["shuffle"],
         io_workers=nworkers,
         prefetch=nmode_prefetch,
     )
     if register and not len(regMat) == 0:
         actImgList = registrationRedux(tn, regMat)
-        dx = findFrameOffset(tn, actImgList, registrationActs)
+        dx = findFrameOffset(tn, actImgList, info["registrationActs"])
     else:
         dx = register
     if save:
@@ -474,12 +487,11 @@ def filterZernikeCube(
 
 def iffRedux(
     tn: str,
-    fileMat: list[list[str]],
+    fileMat: _ot.MatrixLike,
     ampVect: _ot.ArrayLike,
     modeList: _ot.ArrayLike,
     template: _ot.ArrayLike,
     *,
-    shuffle: int = 0,
     io_workers: int = 1,
     prefetch: int = 0,
 ) -> None:
@@ -496,7 +508,7 @@ def iffRedux(
     ----------
     tn : str
         Tracking number of the data in the OPDImages folder.
-    fileMat : ndarray
+    fileMat : MatrixLike
         A matrix of images in string format, in which each row is a mode and the
         columns are its template realization.
     ampVect : float | ArrayLike
@@ -505,10 +517,6 @@ def iffRedux(
         Vector conaining the list of commanded modes.
     template : int | ArrayLike
         Template for the push-pull command actuation.
-    shuffle : int, optional
-        A value different from 0 activates the shuffle option, and the imput
-        value is the number of repetition for each mode's push-pull packet. The
-        default is 0, which means the shuffle is OFF.
     io_workers : int, optional
         Number of threads to use for I/O prefetching. The default is 1.
     prefetch : int, optional
@@ -561,8 +569,7 @@ def iffRedux(
             norm_img = pushPullReductionAlgorithm(
                 imagelist,
                 template,
-                normalization=(_np.max(((template.shape[0] - 1), 1)) * 2 * ampVect[i]),
-                shuffle=shuffle,
+                normalization=(_np.max(((template.shape[0] - 1), 1)) * 2 * ampVect[i])
             )
 
             img_name = _os.path.join(fold, f"mode_{int(modeList[i]):04d}.fits")
@@ -698,7 +705,7 @@ def getTriggerFrame(tn: str, amplitude: int | float = None, roi: int = None) -> 
     return trigFrame
 
 
-def getRegFrames(tn: str, trigFrame: int) -> tuple[int, _ot.ArrayLike]:
+def getRegFrames(tn: str, info: dict[str,_ot.Any]) -> tuple[int, _ot.ArrayLike]:
     """
     Search for the registration frames in the images file list.
 
@@ -706,8 +713,8 @@ def getRegFrames(tn: str, trigFrame: int) -> tuple[int, _ot.ArrayLike]:
     ----------
     tn : str
         Tracking number of the data in the OPDImages folder.
-    trigFrame : int
-        Trigger frame index.
+    info : dict
+        Dictionary containing the information read from the IFFunctions folder.
 
     Returns
     -------
@@ -718,7 +725,8 @@ def getRegFrames(tn: str, trigFrame: int) -> tuple[int, _ot.ArrayLike]:
         Index which identifies the last registration frame in the images file
         list.
     """
-    _, infoR, _, _ = _getAcqInfo(tn)
+    infoR = info['REGISTRATION']
+    trigFrame = info["trigFrame"]
     timing = _rif.getTiming()
     if infoR["zeros"] == 0 and len(infoR["modes"]) == 0:
         regStart = regEnd = (trigFrame + 1) if trigFrame != 0 else 0
@@ -728,7 +736,7 @@ def getRegFrames(tn: str, trigFrame: int) -> tuple[int, _ot.ArrayLike]:
     return regStart, regEnd
 
 
-def getRegFileMatrix(tn: str, trigFrame: int) -> tuple[int, _ot.ArrayLike]:
+def getRegFileMatrix(tn: str, info: dict[str,_ot.Any]) -> tuple[int, _ot.ArrayLike]:
     """
     Search for the registration frames in the images file list, and creates the
     registration file matrix.
@@ -750,14 +758,14 @@ def getRegFileMatrix(tn: str, trigFrame: int) -> tuple[int, _ot.ArrayLike]:
     else:
         fold = None
     fileList = _osu.getFileList(tn, fold="OPDImages" if fold is None else fold)
-    _, infoR, _, _ = _getAcqInfo(tn)
-    regStart, regEnd = getRegFrames(tn, trigFrame)
+    infoR = info['REGISTRATION']
+    regStart, regEnd = getRegFrames(tn, info)
     regList = fileList[regStart:regEnd]
     regMat = _np.reshape(regList, (len(infoR["modes"]), len(infoR["template"])))
     return regMat
 
 
-def getIffFileMatrix(tn: str, trigFrame: int = None) -> _ot.ArrayLike:
+def getIffFileMatrix(tn: str, info: dict[str,_ot.Any]) -> _ot.ArrayLike:
     """
     Creates the iffMat
 
@@ -778,15 +786,54 @@ def getIffFileMatrix(tn: str, trigFrame: int = None) -> _ot.ArrayLike:
         _os.path.isdir(fold)
     else:
         fold = None
-    fileList = _osu.getFileList(tn, fold="OPDImages" if fold is None else fold)
-    _, _, infoIF, _ = _getAcqInfo(tn)
-    _, regEnd = getRegFrames(tn, trigFrame)
-    n_useful_frames = len(infoIF["modes"]) * len(infoIF["template"])
+    fileList = _osu.getFileList(tn, fold=fold)
+
+    infoIF = info['IFFUNC']
+    _, regEnd = getRegFrames(tn, info)
     k = regEnd + infoIF["zeros"]
+    # `k` is the starting point in the file list for the IFF frames
+
+    n_useful_frames = len(info["modesVector"]) * len(info["template"]) # [M x N x T]
     iffList = fileList[k : k + n_useful_frames]
-    iffMat = _np.reshape(iffList, (len(infoIF["modes"]), len(infoIF["template"])))
+    iffMat = _np.reshape(
+        iffList, 
+        (len(infoIF["modes"]), len(infoIF["template"]), info['n_repetitions'])
+    ) # [M, T, N]
     return iffMat
 
+
+def _modes_matrix_reorganization(
+    modesMat: _ot.MatrixLike, info: dict[str,_ot.Any]
+) -> _ot.MatrixLike:
+    """
+    Reorganizes the modes matrix according to the mode list in the info dictionary.
+
+    Parameters
+    ----------
+    modesMat : array-like
+        The original modes matrix, with shape (modes, n_push_pull).
+    info : dict
+        Dictionary containing the information read from the IFFunctions folder.
+
+    Returns
+    -------
+    new_modesMat : array-like
+        The reorganized modes matrix, with shape ``(modes, n_push_pull, n_repetitions)``,
+        where the modes are ordered according to the mode list in the info dictionary.
+    """
+    if not info['shuffle']:
+        return modesMat
+
+    rmodes = info['modesVector']
+    rindex = info['indexList']
+    nrep   = info['n_repetitions']
+    
+    assert nrep == modesMat.shape[2], ValueError(
+        "the IFF file matrix has mismatching ``n_repetitions``: "
+        f"{modesMat.shape[2]} != {nrep}"
+    )
+
+    
 
 def _add_vect_to_mat(
     vector: _ot.ArrayLike,
@@ -889,7 +936,7 @@ def _getCubeList(
 def _getAcqPar(
     tn: str,
 ) -> tuple[
-    _ot.ArrayLike, _ot.ArrayLike, _ot.ArrayLike, _ot.ArrayLike, _ot.ArrayLike, int
+    _ot.ArrayLike, _ot.ArrayLike, _ot.ArrayLike, _ot.ArrayLike, _ot.ArrayLike, bool, int
 ]:
     """
     Reads ad returns the acquisition parameters from fits files.
@@ -901,30 +948,39 @@ def _getAcqPar(
 
     Returns
     -------
-    ampVector : float | ArrayLike
+    dictionary containing the acquisition parameters:
+    - ampVector : float | ArrayLike
         Vector containg the amplitude of each commanded mode.
-    modesVector : int | ArrayLike
+    - modesVector : int | ArrayLike
         Vector containing the list of commanded modes.
-    template : int | ArrayLike
+    - template : int | ArrayLike
         Sampling template ampplied on each mode.
-    indexList : int | ArrayLike
+    - indexList : int | ArrayLike
         Indexing of the modes inside the commanded matrix.
-    registrationActs : int | ArrayLike
+    - registrationActs : int | ArrayLike
         Vector containing the commanded actuators for the registration.
-    shuffle : int
-        Shuffle information. If it's nor 0, the values indicates the number of
-        template sampling repetition for each mode.
+    - shuffle : bool
+        Shuffle information.
+    - n_repetitions : int
+        Number of repetitions for each mode's push-pull packet.
     """
     base = _os.path.join(_ifFold, tn)
-    ampVector = _osu.load_fits(_os.path.join(base, _AMP_FILE))
-    template = _osu.load_fits(_os.path.join(base, _TEMPLATE_FILE))
     modesVector = _osu.load_fits(_os.path.join(base, _MODES_FILE))
     indexList = _osu.load_fits(_os.path.join(base, _INDEXLIST_FILE))
+    ampVector = _osu.load_fits(_os.path.join(base, _AMP_FILE))
+    template = _osu.load_fits(_os.path.join(base, _TEMPLATE_FILE))
     registrationActs = _osu.load_fits(_os.path.join(base, _REGACTS_FILE))
-    with open(_os.path.join(base, _SHUFFLE_FILE), "r", encoding="UTF-8") as shf:
-        shuffle = int(shf.read())
-    return ampVector, modesVector, template, indexList, registrationActs, shuffle
-
+    shuffle = modesVector.header.get("SHUFFLE", False)
+    n_repetitions = modesVector.header.get("N_REP", 1)
+    return {
+        "ampVector": ampVector,
+        "modesVector": modesVector,
+        "template": template,
+        "indexList": indexList,
+        "registrationActs": registrationActs,
+        "shuffle": shuffle,
+        "n_repetitions": n_repetitions
+    }
 
 def _getAcqInfo(
     tn: str = None,
@@ -948,14 +1004,15 @@ def _getAcqInfo(
         Information read about the REGISTRATION options.
     infoIF : dict
         Information read about the IFFUNC option.
+    infoDM : dict
+        Information read about the DM options.
     """
     path = _os.path.join(_ifFold, tn) if tn is not None else _fn.CONFIGURATION_FOLDER
     infoT = _rif.getIffConfig("TRIGGER", bpath=path)
     infoR = _rif.getIffConfig("REGISTRATION", bpath=path)
     infoIF = _rif.getIffConfig("IFFUNC", bpath=path)
-    infoDM = _rif.getDmIffConfig(bpath=path)
+    infoDM = _rif.getIffConfig('DM', bpath=path)
     return infoT, infoR, infoIF, infoDM
-
 
 def _checkStackedCubes(tnlist: str) -> dict[str, _ot.Any]:
     """
@@ -986,6 +1043,28 @@ def _checkStackedCubes(tnlist: str) -> dict[str, _ot.Any]:
         flag = __flag(tnlist, modesVectList, rebin, 0)
     return flag
 
+def _check_information_consistency(info: dict[str, _ot.Any]) -> None:
+    """
+    Checks the consistency of the information read from the IFFunctions folder with
+    respect to the one read from the configuration file.
+
+    Raises
+    ------
+    AssertionError
+        If discrepancies are found within the available information.
+    """
+    M = len(info['IFFUNC']['modes'])*info['n_repetitions']
+    m = len(info['modesVector'])
+    assert M == m, "The expected number of modes does not match the number of" \
+                  f" modes in the modes vector| {M} != {m}"
+    del M,m
+
+    T = len(info['template'])
+    t = info['IFFUNC']['template']
+    assert T == t, f"Template length mismatch! {T} != {t}"
+    del T,t
+    
+    
 
 def __flag(
     tnlist: list[str],

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -858,25 +858,40 @@ def _modes_matrix_reorganization(
     NM = len(info['modesVector'])
 
     ## --- Checks --- ##    
-    assert N == info['n_repetitions'], ValueError(
-        "the IFF file matrix has mismatching ``n_repetitions``: "
-        f"{N} != {info['n_repetitions']}"
-    )
+    if N != info['n_repetitions']:
+        raise ValueError(
+            "the IFF file matrix has mismatching ``n_repetitions``: "
+            f"{N} != {info['n_repetitions']}"
+        )
 
-    assert NM == N*M, ValueError(
-        "the IFF file matrix has mismatching (total) number of modes: "
-        f"{NM} != {N*M}"
-    )
+    if NM != N*M:
+        raise ValueError(
+            "the IFF file matrix has mismatching (total) number of modes: "
+            f"{NM} != {N*M}"
+        )
     ## -------------- ##
 
+    # Get unique mode IDs and create a mapping from mode_id to position (0..M-1)
+    # This handles cases where mode IDs are not sequential (e.g., [4, 21, 34])
+    unique_modes = _np.unique(s_modes)
+    if len(unique_modes) != M:
+        raise ValueError(
+            f"Expected {M} unique modes, but found {len(unique_modes)} in modesVector"
+        )
+    
+    # Create mapping: mode_id -> position in sorted order
+    mode_to_position = {mode_id: pos for pos, mode_id in enumerate(_np.sort(unique_modes))}
+    
     new_modesMat = _np.zeros_like(modesMat)
 
     for i in range(N):
         for j in range(M):
             mode_id = s_modes[i, j]
+            # Map mode_id to its position in the sorted mode list
+            target_position = mode_to_position[mode_id]
             # Mode ``mode_id`` located at row ``j`` in the original matrix, 
-            # is moved to row ``mode_id`` in the new matrix.
-            new_modesMat[i, mode_id, :] = modesMat[i, j, :]
+            # is moved to row ``target_position`` in the new matrix.
+            new_modesMat[i, target_position, :] = modesMat[i, j, :]
 
     return new_modesMat # [N, M, T]
 

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -854,9 +854,8 @@ def _modes_matrix_reorganization(
     # Shuffled case
     N, M, T = modesMat.shape
     
-    # indexList contains the shuffle indices: indexList[j] tells us that the mode
-    # at position j in the shuffled acquisition was originally at position indexList[j]
-    # in the requested modesList
+    # indexList[i, j] stores the original position (in the requested modesList) of the
+    # mode that was placed at position j during repetition i of the shuffled acquisition
     indexList = _np.asarray(info['indexList'].reshape((N, M)), dtype=int)  # [N, M]
     
     NM = len(info['modesVector'])
@@ -879,9 +878,7 @@ def _modes_matrix_reorganization(
 
     for i in range(N):
         for j in range(M):
-            # The mode at position j in the shuffled acquisition was originally
-            # at position indexList[i, j] in the requested modesList.
-            # Move data from shuffled position j to original position indexList[i, j]
+            # Restore original order: move data from shuffled position j to original position
             original_position = indexList[i, j]
             new_modesMat[i, original_position, :] = modesMat[i, j, :]
 

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -856,7 +856,7 @@ def _modes_matrix_reorganization(
     
     # indexList[i, j] stores the original position (in the requested modesList) of the
     # mode that was placed at position j during repetition i of the shuffled acquisition
-    indexList = _np.asarray(info['indexList'].reshape((N, M)), dtype=int)  # [N, M]
+    shuffled_modes = _np.asarray(info['modesVector'].reshape((N, M)), dtype=int)  # [N, M]
     
     NM = len(info['modesVector'])
 
@@ -875,12 +875,25 @@ def _modes_matrix_reorganization(
     ## -------------- ##
 
     new_modesMat = _np.zeros_like(modesMat)
+    
+    modes_to_pos = {}
+    for i in range(shuffled_modes.shape[0]):
+        modes_to_pos[i] = {}
+        sorted_modes = _np.sort(shuffled_modes[i])
+        for shuffle_idx, mode in enumerate(shuffled_modes[i]):
+            for target_idx in range(len(shuffled_modes[i])):
+                if mode == sorted_modes[target_idx]:
+                    modes_to_pos[i][shuffle_idx] = target_idx
+                    break
+
+    # the `modes_to_pos` dictionary, indexed at the higest level by the repetition
+    # index, has the mapping {shuffled_position_id: target_position_id}
 
     for i in range(N):
-        for j in range(M):
-            # Restore original order: move data from shuffled position j to original position
-            original_position = indexList[i, j]
-            new_modesMat[i, original_position, :] = modesMat[i, j, :]
+        mapping = modes_to_pos[i]
+        for shuffle_idx in mapping.keys():
+            target_idx = mapping[shuffle_idx]
+            new_modesMat[i, target_idx, :] = modesMat[i, shuffle_idx, :]
 
     return new_modesMat # [N, M, T]
 

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -853,6 +853,8 @@ def _modes_matrix_reorganization(
 
     # Shuffled case
     N, M, T = modesMat.shape
+    # s_modes contains the shuffled mode IDs from the acquisition, reshaped to [N, M]
+    # where N is the number of repetitions and M is the number of modes per repetition
     s_modes = _np.asarray(info['modesVector'].reshape((N,M)),dtype=int) # [N, M]
     
     NM = len(info['modesVector'])
@@ -873,6 +875,7 @@ def _modes_matrix_reorganization(
 
     # Get unique mode IDs and create a mapping from mode_id to position (0..M-1)
     # This handles cases where mode IDs are not sequential (e.g., [4, 21, 34])
+    # np.unique returns sorted values, so we can use them directly
     unique_modes = _np.unique(s_modes)
     if len(unique_modes) != M:
         raise ValueError(
@@ -880,7 +883,7 @@ def _modes_matrix_reorganization(
         )
     
     # Create mapping: mode_id -> position in sorted order
-    mode_to_position = {mode_id: pos for pos, mode_id in enumerate(_np.sort(unique_modes))}
+    mode_to_position = {mode_id: pos for pos, mode_id in enumerate(unique_modes)}
     
     new_modesMat = _np.zeros_like(modesMat)
 

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -538,13 +538,15 @@ def iffRedux(
     from opticalib.analyzer import pushPullReductionAlgorithm
 
     fold = _os.path.join(_ifFold, tn)
-    
-    N, M, T = fileMat.shape
 
-    # Helper: read one mode's frame block
-    def _read_mode(paths: list[str]) -> list[_ot.ImageData]:
-        # Sequential reads inside a worker to keep per-mode locality
-        return [_osu.read_phasemap(p) for p in paths]
+    N, M, T = fileMat.shape
+    
+    if _np.size(ampVect) == 1:
+        ampVect = _np.full(M, ampVect, dtype=_np.float32)
+
+    # Updated helper: now follows tensor logic:
+    def _read_block(rep_idx: int, mode_idx: int) -> list[_ot.ImageData]:
+        return [_osu.read_phasemap(p) for p in fileMat[rep_idx, mode_idx, :]]
 
     ## NEW METHOD: THREADING I/O WORKERS WITH PREFETCHING ##
     # ---------------------------------------------------- #
@@ -553,40 +555,58 @@ def iffRedux(
     io_workers = max(1, int(io_workers))
     prefetch = max(0, int(prefetch))
 
-    futures: dict[int, _ot.Any] = {}
     with _tpe(max_workers=io_workers) as ex:
-        for j in range(min(prefetch, nmodes)):
-            futures[j] = ex.submit(_read_mode, fileMat[j, :])
+        futures: dict[int, _ot.Any] = {}
 
-        for i in _tqdm(
-            range(nmodes), desc="Processing...", total=nmodes, unit="modes", ncols=80
+        # New helper for scheduling a mode within the repetitions.
+        def _schedule_mode(mode_idx: int) -> None:
+            if mode_idx >= M:
+                return
+            for rep_idx in range(N):
+                key = (rep_idx, mode_idx)
+                if key not in futures:
+                    futures[key] = ex.submit(_read_block, rep_idx, mode_idx)
+
+        for mode_idx in range(min(M, prefetch + 1)):
+            _schedule_mode(mode_idx)
+
+        for mode_idx in _tqdm(
+            range(M), desc="Processing...", total=M, unit="modes", ncols=85
         ):
-            # Ensure current mode is scheduled
-            if i not in futures:
-                futures[i] = ex.submit(_read_mode, fileMat[i, :])
+            _schedule_mode(mode_idx + prefetch + 1)
 
-            # Fetch prefetched images (waits here if not yet done)
-            imagelist = futures[i].result()
-            del futures[i]
+            sum_data = None
+            union_mask = None
 
-            # Schedule next mode to keep window full
-            j = i + prefetch
-            if j < nmodes and j not in futures:
-                futures[j] = ex.submit(_read_mode, fileMat[j, :])
+            for rep_idx in range(N):
+                imgs = futures.pop((rep_idx, mode_idx)).result()
+                red = pushPullReductionAlgorithm(
+                    imgs,
+                    template,
+                    normalization=max(len(template) - 1, 1) * 2 * ampVect[mode_idx],
+                )
 
-            norm_img = pushPullReductionAlgorithm(
-                imagelist,
-                template,
-                normalization=(_np.max(((template.shape[0] - 1), 1)) * 2 * ampVect[i])
+                if sum_data is None:
+                    sum_data = red.data.astype(_np.float32, copy=True)
+                    union_mask = red.mask.copy()
+                else:
+                    sum_data += red.data
+                    union_mask |= red.mask
+
+            mode_img = _np.ma.masked_array(sum_data / n_repetitions, mask=union_mask)
+
+            _osu.save_fits(
+                _os.path.join(fold, f"mode_{int(modeList[mode_idx]):04d}.fits"),
+                mode_img,
+                overwrite=True,
+                header={
+                    "MODEID": (int(modeList[mode_idx]), "mode id"),
+                    "AMP": (float(ampVect[mode_idx]), "mode amplitude"),
+                    "TEMPLATE": (len(template), "push-pull length"),
+                    "NREP": (int(n_repetitions), "averaged repetitions"),
+                },
             )
-
-            img_name = _os.path.join(fold, f"mode_{int(modeList[i]):04d}.fits")
-            header = {
-                "MODEID": (int(modeList[i]), "mode id"),
-                "AMP": (float(ampVect[i]), "mode amplitude"),
-                "TEMPLATE": (len(template), "push-pull length"),
-            }
-            _osu.save_fits(img_name, norm_img, overwrite=True, header=header)
+            
 
 
 def registrationRedux(tn: str, fileMat: list[str]) -> list[_ot.ImageData]:
@@ -829,7 +849,7 @@ def _modes_matrix_reorganization(
     """
     # Not shuffled case
     if not info['shuffle']:
-        return _squash_mode_matrix(modesMat)
+        return modesMat
 
     # Shuffled case
     N, M, T = modesMat.shape
@@ -858,33 +878,8 @@ def _modes_matrix_reorganization(
             # is moved to row ``mode_id`` in the new matrix.
             new_modesMat[i, mode_id, :] = modesMat[i, j, :]
 
-    return new_modesMat.reshape((NM, T))
+    return new_modesMat # [N, M, T]
 
-def _squash_mode_matrix(modesMat: _ot.MatrixLike) -> _ot.MatrixLike:
-    """
-    Squashes the mode matrix by removing the repetitions dimension, if it is 1.
-
-    Parameters
-    ----------
-    modesMat : array-like
-        The original modes matrix, with shape (modes, n_push_pull, n_repetitions).
-
-    Returns
-    -------
-    new_modesMat : array-like
-        The squashed modes matrix, with shape (modes, n_push_pull), if n_repetitions is 1.
-        Otherwise, returns the original modes matrix.
-    """
-    try:
-        N, M, T= modesMat.shape
-    except TypeError:
-        # modesMat is already 2D
-        return modesMat
-    
-    if N == 1:
-        return modesMat[0]
-    else:
-        return modesMat.reshape((M*N, T))
 
 def _add_vect_to_mat(
     vector: _ot.ArrayLike,
@@ -984,11 +979,7 @@ def _getCubeList(
     return cubeList, matrixList, modesVectList, rebin
 
 
-def _getAcqPar(
-    tn: str,
-) -> tuple[
-    _ot.ArrayLike, _ot.ArrayLike, _ot.ArrayLike, _ot.ArrayLike, _ot.ArrayLike, bool, int
-]:
+def _getAcqPar(tn: str) -> dict[str,_ot.ArrayLike | bool | int]:
     """
     Reads ad returns the acquisition parameters from fits files.
 

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -853,9 +853,11 @@ def _modes_matrix_reorganization(
 
     # Shuffled case
     N, M, T = modesMat.shape
-    # s_modes contains the shuffled mode IDs from the acquisition, reshaped to [N, M]
-    # where N is the number of repetitions and M is the number of modes per repetition
-    s_modes = _np.asarray(info['modesVector'].reshape((N,M)),dtype=int) # [N, M]
+    
+    # indexList contains the shuffle indices: indexList[j] tells us that the mode
+    # at position j in the shuffled acquisition was originally at position indexList[j]
+    # in the requested modesList
+    indexList = _np.asarray(info['indexList'].reshape((N, M)), dtype=int)  # [N, M]
     
     NM = len(info['modesVector'])
 
@@ -873,28 +875,15 @@ def _modes_matrix_reorganization(
         )
     ## -------------- ##
 
-    # Get unique mode IDs and create a mapping from mode_id to position (0..M-1)
-    # This handles cases where mode IDs are not sequential (e.g., [4, 21, 34])
-    # np.unique returns sorted values, so we can use them directly
-    unique_modes = _np.unique(s_modes)
-    if len(unique_modes) != M:
-        raise ValueError(
-            f"Expected {M} unique modes, but found {len(unique_modes)} in modesVector"
-        )
-    
-    # Create mapping: mode_id -> position in sorted order
-    mode_to_position = {mode_id: pos for pos, mode_id in enumerate(unique_modes)}
-    
     new_modesMat = _np.zeros_like(modesMat)
 
     for i in range(N):
         for j in range(M):
-            mode_id = s_modes[i, j]
-            # Map mode_id to its position in the sorted mode list
-            target_position = mode_to_position[mode_id]
-            # Mode ``mode_id`` located at row ``j`` in the original matrix, 
-            # is moved to row ``target_position`` in the new matrix.
-            new_modesMat[i, target_position, :] = modesMat[i, j, :]
+            # The mode at position j in the shuffled acquisition was originally
+            # at position indexList[i, j] in the requested modesList.
+            # Move data from shuffled position j to original position indexList[i, j]
+            original_position = indexList[i, j]
+            new_modesMat[i, original_position, :] = modesMat[i, j, :]
 
     return new_modesMat # [N, M, T]
 

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -1087,24 +1087,38 @@ def _checkStackedCubes(tnlist: str) -> dict[str, _ot.Any]:
 
 def _check_information_consistency(info: dict[str, _ot.Any]) -> None:
     """
-    Checks the consistency of the information read from the IFFunctions folder with
-    respect to the one read from the configuration file.
+    Check consistency between folder metadata and configuration metadata.
+
+    Parameters
+    ----------
+    info : dict[str, _ot.Any]
+        Dictionary containing acquisition metadata gathered from the
+        IFFunctions folder and the related configuration.
 
     Raises
     ------
-    AssertionError
-        If discrepancies are found within the available information.
+    ValueError
+        Raised when the number of modes or template lengths do not match
+        the expected values from the configuration.
     """
-    M = len(info['IFFUNC']['modes'])*info['n_repetitions']
-    m = len(info['modesVector'])
-    assert M == m, "The expected number of modes does not match the number of" \
-                  f" modes in the modes vector| {M} != {m}"
-    del M,m
+    expected_modes_count = (
+        len(info["IFFUNC"]["modes"]) * info["n_repetitions"]
+    )
+    actual_modes_count = len(info["modesVector"])
+    if expected_modes_count != actual_modes_count:
+        raise ValueError(
+            "Expected number of modes does not match the number of "
+            "entries in the modes vector: "
+            f"{expected_modes_count} != {actual_modes_count}"
+        )
 
-    T = len(info['template'])
-    t = len(info['IFFUNC']['template'])
-    assert T == t, f"Template length mismatch! {T} != {t}"
-    del T,t
+    folder_template_length = len(info["template"])
+    config_template_length = len(info["IFFUNC"]["template"])
+    if folder_template_length != config_template_length:
+        raise ValueError(
+            "Template length mismatch: "
+            f"{folder_template_length} != {config_template_length}"
+        )
 
 
 def __flag(

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -140,14 +140,17 @@ def process(
     modesMat = getIffFileMatrix(tn, info)
     
     modesMat = _modes_matrix_reorganization(modesMat, info)
+    # At this point, the ``modesMat`` is reordered as 0,1,..,M-1, where M is 
+    # the number of modes, and is of shape (N, M, T), where: N is the number of 
+    # template realizations, and T is the push-pull template sequence.
 
     iffRedux(
         tn=tn,
         fileMat=modesMat,
-        ampVect=info["ampVector"],
-        modeList=info["modesVector"],
+        ampVect=info['IFFUNC']["amplitude"],
+        modeList=info['IFFUNC']["modes"],
         template=info["template"],
-        shuffle=info["shuffle"],
+        n_repetitions=info['n_repetitions'],
         io_workers=nworkers,
         prefetch=nmode_prefetch,
     )
@@ -482,6 +485,7 @@ def filterZernikeCube(
         _sh.copyfile(CmdMat, _os.path.join(new_tn, _MATRIX_FILE))
         _sh.copyfile(ModesVec, _os.path.join(new_tn, _MODES_FILE))
         print(f"Filtered cube saved at {new_tn}")
+
     return ffcube, new_tn.split("/")[-1]
 
 
@@ -491,6 +495,7 @@ def iffRedux(
     ampVect: _ot.ArrayLike,
     modeList: _ot.ArrayLike,
     template: _ot.ArrayLike,
+    n_repetitions: int = 1,
     *,
     io_workers: int = 1,
     prefetch: int = 0,
@@ -517,6 +522,8 @@ def iffRedux(
         Vector conaining the list of commanded modes.
     template : int | ArrayLike
         Template for the push-pull command actuation.
+    n_repetitions : int, optional
+        Number of repetitions for each mode. The default is 1.
     io_workers : int, optional
         Number of threads to use for I/O prefetching. The default is 1.
     prefetch : int, optional
@@ -531,7 +538,8 @@ def iffRedux(
     from opticalib.analyzer import pushPullReductionAlgorithm
 
     fold = _os.path.join(_ifFold, tn)
-    nmodes = len(modeList)
+    
+    N, M, T = fileMat.shape
 
     # Helper: read one mode's frame block
     def _read_mode(paths: list[str]) -> list[_ot.ImageData]:
@@ -704,7 +712,6 @@ def getTriggerFrame(tn: str, amplitude: int | float = None, roi: int = None) -> 
     trigFrame = i
     return trigFrame
 
-
 def getRegFrames(tn: str, info: dict[str,_ot.Any]) -> tuple[int, _ot.ArrayLike]:
     """
     Search for the registration frames in the images file list.
@@ -734,7 +741,6 @@ def getRegFrames(tn: str, info: dict[str,_ot.Any]) -> tuple[int, _ot.ArrayLike]:
         regStart = trigFrame + infoR["zeros"] * timing + (1 if trigFrame != 0 else 0)
         regEnd = regStart + len(infoR["modes"]) * len(infoR["template"]) * timing
     return regStart, regEnd
-
 
 def getRegFileMatrix(tn: str, info: dict[str,_ot.Any]) -> tuple[int, _ot.ArrayLike]:
     """
@@ -779,14 +785,14 @@ def getIffFileMatrix(tn: str, info: dict[str,_ot.Any]) -> _ot.ArrayLike:
     iffMat : ndarray
         A matrix of images in string format, conatining all the images for the
         IFF acquisition, that is all the modes with each push-pull realization.
-        It has shape (modes, n_push_pull)
+        It has shape ``(n_repetitions, n_modes, n_push_pull)``
     """
     if not _osu.is_tn(tn):
         fold = tn[:-15]
         _os.path.isdir(fold)
     else:
         fold = None
-    fileList = _osu.getFileList(tn, fold=fold)
+    fileList = _osu.getFileList(tn, fold=fold, key='image_')
 
     infoIF = info['IFFUNC']
     _, regEnd = getRegFrames(tn, info)
@@ -797,8 +803,8 @@ def getIffFileMatrix(tn: str, info: dict[str,_ot.Any]) -> _ot.ArrayLike:
     iffList = fileList[k : k + n_useful_frames]
     iffMat = _np.reshape(
         iffList, 
-        (len(infoIF["modes"]), len(infoIF["template"]), info['n_repetitions'])
-    ) # [M, T, N]
+        (info['n_repetitions'], len(infoIF["modes"]), len(infoIF["template"]))
+    ) # [N, M, T]
     return iffMat
 
 
@@ -810,30 +816,75 @@ def _modes_matrix_reorganization(
 
     Parameters
     ----------
-    modesMat : array-like
-        The original modes matrix, with shape (modes, n_push_pull).
+    modesMat : MatrixLike
+        The original modes matrix, with shape (n_repetitions, modes, n_push_pull).
     info : dict
         Dictionary containing the information read from the IFFunctions folder.
 
     Returns
     -------
-    new_modesMat : array-like
-        The reorganized modes matrix, with shape ``(modes, n_push_pull, n_repetitions)``,
-        where the modes are ordered according to the mode list in the info dictionary.
+    new_modesMat : MatrixLike
+        The reorganized modes matrix, with shape ``(n_repetitions, modes, n_push_pull)``,
+        where the modes are re-ordered as 0,1,..,M-1.
     """
+    # Not shuffled case
     if not info['shuffle']:
-        return modesMat
+        return _squash_mode_matrix(modesMat)
 
-    rmodes = info['modesVector']
-    rindex = info['indexList']
-    nrep   = info['n_repetitions']
+    # Shuffled case
+    N, M, T = modesMat.shape
+    s_modes = _np.asarray(info['modesVector'].reshape((N,M)),dtype=int) # [N, M]
     
-    assert nrep == modesMat.shape[2], ValueError(
+    NM = len(info['modesVector'])
+
+    ## --- Checks --- ##    
+    assert N == info['n_repetitions'], ValueError(
         "the IFF file matrix has mismatching ``n_repetitions``: "
-        f"{modesMat.shape[2]} != {nrep}"
+        f"{N} != {info['n_repetitions']}"
     )
 
+    assert NM == N*M, ValueError(
+        "the IFF file matrix has mismatching (total) number of modes: "
+        f"{NM} != {N*M}"
+    )
+    ## -------------- ##
+
+    new_modesMat = _np.zeros_like(modesMat)
+
+    for i in range(N):
+        for j in range(M):
+            mode_id = s_modes[i, j]
+            # Mode ``mode_id`` located at row ``j`` in the original matrix, 
+            # is moved to row ``mode_id`` in the new matrix.
+            new_modesMat[i, mode_id, :] = modesMat[i, j, :]
+
+    return new_modesMat.reshape((NM, T))
+
+def _squash_mode_matrix(modesMat: _ot.MatrixLike) -> _ot.MatrixLike:
+    """
+    Squashes the mode matrix by removing the repetitions dimension, if it is 1.
+
+    Parameters
+    ----------
+    modesMat : array-like
+        The original modes matrix, with shape (modes, n_push_pull, n_repetitions).
+
+    Returns
+    -------
+    new_modesMat : array-like
+        The squashed modes matrix, with shape (modes, n_push_pull), if n_repetitions is 1.
+        Otherwise, returns the original modes matrix.
+    """
+    try:
+        N, M, T= modesMat.shape
+    except TypeError:
+        # modesMat is already 2D
+        return modesMat
     
+    if N == 1:
+        return modesMat[0]
+    else:
+        return modesMat.reshape((M*N, T))
 
 def _add_vect_to_mat(
     vector: _ot.ArrayLike,
@@ -1060,11 +1111,10 @@ def _check_information_consistency(info: dict[str, _ot.Any]) -> None:
     del M,m
 
     T = len(info['template'])
-    t = info['IFFUNC']['template']
+    t = len(info['IFFUNC']['template'])
     assert T == t, f"Template length mismatch! {T} != {t}"
     del T,t
-    
-    
+
 
 def __flag(
     tnlist: list[str],

--- a/opticalib/dmutils/iff_processing.py
+++ b/opticalib/dmutils/iff_processing.py
@@ -812,7 +812,7 @@ def getIffFileMatrix(tn: str, info: dict[str,_ot.Any]) -> _ot.ArrayLike:
         _os.path.isdir(fold)
     else:
         fold = None
-    fileList = _osu.getFileList(tn, fold=fold, key='image_')
+    fileList = _osu.getFileList(tn, fold="OPDImages" if fold is None else fold, key='image_')
 
     infoIF = info['IFFUNC']
     _, regEnd = getRegFrames(tn, info)

--- a/opticalib/simulator/_API/base_fake_adopticadm.py
+++ b/opticalib/simulator/_API/base_fake_adopticadm.py
@@ -12,7 +12,7 @@ from opticalib import typings as _t
 from opticalib.ground import geometry as geo
 from opticalib.ground import osutils as osu
 from opticalib.ground import roi
-from opticalib.core.read_config import getDmIffConfig as _dmc
+from opticalib.core.read_config import getIffConfig as _dmc
 from opticalib.ground.modal_decomposer import ZernikeFitter as _ZF
 from .simdata import get_simdata_file
 
@@ -211,7 +211,7 @@ class BaseFakeDp:
 
     def __init__(self, force_recompute: bool = False):
         """The constuctor"""
-        dmc = _dmc()
+        dmc = _dmc('DM')
         self._name = "AdOpticaDP"
         self.mirrorModes = osu.load_fits(get_simdata_file("dp_cmdmat.fits"))
         self.ff = osu.load_fits(get_simdata_file("dp_ffwd.fits"))

--- a/opticalib/simulator/_API/base_fake_alpao.py
+++ b/opticalib/simulator/_API/base_fake_alpao.py
@@ -4,7 +4,7 @@ import numpy as np
 from ... import typings as _t
 from ..factory_functions import *
 from ...core import root as _root
-from ...core.read_config import getDmIffConfig as _dmc
+from ...core.read_config import getIffConfig as _dmc
 from abc import ABC, abstractmethod
 from opticalib.ground import osutils as osu
 from ._rbf_gpu import RBFInterpolator
@@ -30,7 +30,7 @@ class BaseFakeAlpao(ABC):
         self.ZM = None
         self.RM = None
         self._load_matrices()
-        dmc = _dmc()
+        dmc = _dmc('DM')
         self._slaveIds = dmc.get("slaveIds", [])
         self._borderIds = dmc.get("borderIds", [])
 

--- a/opticalib/visualization.py
+++ b/opticalib/visualization.py
@@ -232,6 +232,7 @@ def superimshow(
     titles: list[str] | str = None,
     xlabels: list[str] | str = None,
     ylabels: list[str] | str = None,
+    set_axis_off: bool = False,
     *mplargs: _ot.Any,
     **mplkwargs: dict[str, _ot.Any],
 ):
@@ -252,6 +253,8 @@ def superimshow(
         List of x-axis labels for each image. If not provided, the labels are 'X [px]'.
     ylabels : list or str, optional
         List of y-axis labels for each image. If not provided, the labels are 'Y [px]'.
+    set_axis_off : bool, optional
+        If True, the axes will be turned off. The default is False.
     *mplargs
         Additional arguments to be passed to `imshow`.
     **mplkwargs
@@ -264,6 +267,8 @@ def superimshow(
     axs : numpy.ndarray
         Array of axes objects corresponding to each subplot.
     """
+    # TODO: add the possibility to set the axis off. Useful for small images.
+
     import matplotlib.pyplot as plt
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 
@@ -287,6 +292,7 @@ def superimshow(
     )
     ncol = int(np.ceil(np.sqrt(Nplots))) if ncols is None else ncols
     nrow = int(np.ceil(Nplots / ncol)) if nrows is None else nrows
+
     if (nrow * ncol) < Nplots:
         raise ValueError(
             f"Number of rows and columns is not enough to display {Nplots} images."
@@ -309,6 +315,8 @@ def superimshow(
         ax.set_xlabel(xlabel[i])
         ax.set_ylabel(ylabel[i])
         ax.set_aspect("equal")
+        if set_axis_off:
+            ax.axis("off")
         # Aggiunta del colorbar
         fig.colorbar(im, cax=cax)
     # Se rimangono assi vuoti, li spegniamo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,7 +202,6 @@ def sample_iff_folder_structure(temp_dir, monkeypatch):
         "indexList.fits": np.array([0, 1, 2]),
         "regActs.fits": np.array([1, 2]),
         "cmdMatrix.fits": np.random.randn(100, 3).astype(np.float32),
-        "shuffle.dat": "0",
     }
 
     for fname, data in files_to_create.items():

--- a/tests/test_dmutils_iff_acquisition_preparation.py
+++ b/tests/test_dmutils_iff_acquisition_preparation.py
@@ -725,3 +725,35 @@ class TestIFFCapturePreparation:
 
         assert prep.modalBaseId == "hadamard"
         assert prep._modalBase.shape[0] == mock_dm.nActs
+
+    @patch("opticalib.dmutils.iff_acquisition_preparation._getAcqInfo")
+    def test_create_cmd_matrix_history_invalid_n_repetitions(
+        self, mock_get_info, mock_dm
+    ):
+        """Test that createCmdMatrixHistory raises ValueError for invalid n_repetitions."""
+        mock_get_info.return_value = (
+            None,
+            None,
+            {
+                "modes": [0, 1, 2],
+                "amplitude": 0.1,
+                "template": [1, -1],
+                "zeros": 0,
+            },
+            None,
+        )
+
+        prep = ifa.IFFCapturePreparation(mock_dm)
+
+        # Test n_repetitions = 0
+        with pytest.raises(ValueError, match="n_repetitions must be >= 1"):
+            prep.createCmdMatrixHistory(modesList=np.arange(5), n_repetitions=0)
+
+        # Test n_repetitions = -1
+        with pytest.raises(ValueError, match="n_repetitions must be >= 1"):
+            prep.createCmdMatrixHistory(modesList=np.arange(5), n_repetitions=-1)
+
+        # Test n_repetitions = -10
+        with pytest.raises(ValueError, match="n_repetitions must be >= 1"):
+            prep.createCmdMatrixHistory(modesList=np.arange(5), n_repetitions=-10)
+

--- a/tests/test_dmutils_iff_processing.py
+++ b/tests/test_dmutils_iff_processing.py
@@ -286,7 +286,6 @@ class TestGetAcqInfo:
     """Test _getAcqInfo function."""
 
     @patch("opticalib.dmutils.iff_processing._rif.getIffConfig")
-    @patch("opticalib.dmutils.iff_processing._rif.getDmIffConfig")
     def test_get_acq_info(self, mock_dm_config, mock_iff_config, temp_dir, monkeypatch):
         """Test getting acquisition info."""
         from opticalib.core.root import folders
@@ -316,6 +315,12 @@ class TestGetAcqInfo:
                 "template": [1, -1],
                 "modalBase": "mirror",
                 "paddingZeros": 0,
+            },
+            {
+                "nacts": 100,
+                "timing": 10,
+                "delay": 5,
+                "triggerMode": False,
             },
         ]
         mock_dm_config.return_value = {"nacts": 100, "timing": 10}

--- a/tests/test_dmutils_iff_processing.py
+++ b/tests/test_dmutils_iff_processing.py
@@ -270,23 +270,22 @@ class TestGetAcqPar:
 
         tn, tn_folder = sample_iff_folder_structure
 
-        ampVector, modesVector, template, indexList, registrationActs, shuffle = (
-            ifp._getAcqPar(tn)
-        )
+        ret = ifp._getAcqPar(tn)
 
-        assert ampVector is not None
-        assert modesVector is not None
-        assert template is not None
-        assert indexList is not None
-        assert registrationActs is not None
-        assert isinstance(shuffle, int)
+        assert ret["ampVector"] is not None
+        assert ret["modesVector"] is not None
+        assert ret["template"] is not None
+        assert ret["indexList"] is not None
+        assert ret["registrationActs"] is not None
+        assert isinstance(ret["shuffle"], bool)
+        assert isinstance(ret['n_repetitions'], int)
 
 
 class TestGetAcqInfo:
     """Test _getAcqInfo function."""
 
     @patch("opticalib.dmutils.iff_processing._rif.getIffConfig")
-    def test_get_acq_info(self, mock_dm_config, mock_iff_config, temp_dir, monkeypatch):
+    def test_get_acq_info(self, mock_iff_config, temp_dir, monkeypatch):
         """Test getting acquisition info."""
         from opticalib.core.root import folders
 
@@ -323,7 +322,6 @@ class TestGetAcqInfo:
                 "triggerMode": False,
             },
         ]
-        mock_dm_config.return_value = {"nacts": 100, "timing": 10}
 
         config_folder = os.path.join(temp_dir, "SysConfig")
         os.makedirs(config_folder, exist_ok=True)


### PR DESCRIPTION
# IFF acquisition and processing with mode shuffling and multiple repetitions

## IFFAcquisitionPreparation

Nothing much to add to what's been done already. The `TimedCommandHistory` creation works as intended, and now supports both `shuffle: bool` and `n_repetitions: int` indipendently.

## IFF Processing

Adjusted with the new logic to support the cases:

- `shuffle=False` and `n_repetitions` $\ge$ 1
- `shuffle=True`  and `n_repetitions` $\ge$ 1

A new `_mode_matrix_reorganization` function has been added to manage the modes reorganization.

### Test case
Tested with the `AlpaoDM 88` simulator:
- `tn = opt.dmutils.iff_module.iffDataAcquisition(dm, interf, modesList=np.arange(16), amplitude=0.1, shuffle=False, n_repetitions=1)`
- `tn = opt.dmutils.iff_module.iffDataAcquisition(dm, interf, modesList=np.arange(16), amplitude=0.1, shuffle=False, n_repetitions=2)`
- `tn = opt.dmutils.iff_module.iffDataAcquisition(dm, interf, modesList=np.arange(16), amplitude=0.1, shuffle=True, n_repetitions=1)`
- `tn = opt.dmutils.iff_module.iffDataAcquisition(dm, interf, modesList=np.arange(16), amplitude=0.1, shuffle=True, n_repetitions=4)`

Plot with show the correct order of the modes in the last case:

<img width="1383" height="889" alt="Image" src="https://github.com/user-attachments/assets/47636383-b093-4cba-ad92-09695f24dfe0" />